### PR TITLE
Edit recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.lock
 *.pyc
+*.swp
 __pycache__/
 docs/_site/

--- a/app/document_models/recipe_documents.py
+++ b/app/document_models/recipe_documents.py
@@ -45,7 +45,7 @@ class Recipe(db.Document):
         media_type               Type of supplemental media provided. Required.
                                         takes a string.
 
-        instruction             Steps of recipe. Optional.
+        instructions             Steps of recipe. Optional.
                                         takes a list of strings.
 
         tips                    Tips related to recipe. Optional.

--- a/app/document_models/recipe_documents.py
+++ b/app/document_models/recipe_documents.py
@@ -57,7 +57,7 @@ class Recipe(db.Document):
         description = db.StringField(required=True)
         submitter = db.StringField(required=False)
 
-        difficulty = db.IntField(required=False)
+        difficulty = db.StringField(required=False)
         time = db.StringField(required=False)
         servings = db.StringField(required=False)
 

--- a/app/document_models/tip_documents.py
+++ b/app/document_models/tip_documents.py
@@ -1,37 +1,45 @@
 from flask_mongoalchemy import *
 from app import db
+from app.helper_functions.query_helpers import TipQuery
 
 class Tip(db.Document):
-	"""
-	Represents the definition of a tip in the
-	repository.
+        """
+        Represents the definition of a tip in the
+        repository.
 
-	Fields:
-	title			Title of the tip. Required.
-					takes a string.
+        Fields:
+        tip_name                Name of the tip. Required.
+                                        takes a string.
 
-	text			The tip itself. Required.
-					takes a string
+        text                    The tip itself. Required.
+                                        takes a string
 
-	submitter		Name of the submitter. Required.
-					takes a string
+        submitter               Name of the submitter. Required.
+                                        takes a string
 
-	related_equip	Names of equipment that might relate to this tip. Optional.
-					takes a list of strings
+        related_equip   Names of equipment that might relate to this tip. Optional.
+                                        takes a list of strings
 
-	related_ingr	Names of ingredients that might relate to this tip. Optional.
-					takes a list of strings
+        related_ingr    Names of ingredients that might relate to this tip. Optional.
+                                        takes a list of strings
 
-	aud_vid			Audio/video component. Optional.
-					takes a url
-	"""
+        aud_vid                 Audio/video component. Optional.
+                                        takes a url
+        """
         # TODO: update schema to match tip form fields.
-	tip_id = db.ObjectIdField()
-	title = db.StringField(required=True)
-	text = db.StringField(required=True)
-	submitter = db.StringField(required=True)
+        query_class = TipQuery
 
-	related_equip = db.ListField(db.StringField())
-	related_ingr = db.ListField(db.StringField())
+        tip_name = db.StringField(required=True)
+        media_type = db.StringField(required=True)
+        media_url = db.StringField(required=False)
+        video_id = db.StringField(required=False)
+        submitter = db.StringField(required=False)
+        description = db.StringField(required=True)
+        difficulty = db.StringField(required=True)
+        equipment = db.ListField(db.StringField(required=False), required=False)
+        ingredients = db.ListField(db.StringField(required=False), required=False)
+        instructions = db.ListField(db.StringField(required=False), required=False)
+        tags = db.ListField(db.StringField(required=False), required=False)
 
-	aud_vid = db.AnythingField(required=False)
+        def get_id(self):
+            return str(self.mongo_id)

--- a/app/helper_functions/query_helpers.py
+++ b/app/helper_functions/query_helpers.py
@@ -38,3 +38,21 @@ class RecipeQuery(BaseQuery):
 
     def has_equip(self, equip):
         return self.filter(self.type.equipment.in_(equip))
+
+class TipQuery(BaseQuery):
+    def tip_from_dict(self, search_dict):
+        """Looks for matches from a search dictionary
+        """
+        params_tip = {
+                'tip_name': lambda name: {'tip_name': {'$options': 'i', '$regex': name}},
+                'tags': lambda tags: {'tags': {'$in': tags}},
+                'ingredients': lambda ingredients: {'tags': {'$in': ingredients}},
+                'equipment': lambda equip: {'tags': {'$in': equip}}
+        }
+
+        query_tips = {}
+        for key, pattern in params_tip.items():
+            if key in search_dict.keys() and search_dict[key] != []:
+                query_tips.update(pattern(search_dict[key]))
+
+        return self.filter(query_tips)

--- a/app/routes.py
+++ b/app/routes.py
@@ -4,7 +4,7 @@ from app.document_models.tip_documents import Tip
 from app.forms import RecipeSearchForm
 from app import app
 from app.helper_functions.media import video_id_from_url
-from app.helper_functions.conversions import request_to_dict, form_to_recipe_dict
+from app.helper_functions.conversions import request_to_dict, form_to_recipe_dict, form_to_tip_dict
 
 @app.route('/')
 @app.route('/index')
@@ -17,6 +17,15 @@ def recipe():
     content = '<h1>Recipes</h1><ol>'
     for recipe in recipes:
         content += '<li>{}</li>'.format(recipe.recipe_name)
+    content += '</ol>'
+    return content
+
+@app.route('/tip')
+def tip():
+    tips = Tip.query.all()
+    content = '<h1>Tips</h1><ol>'
+    for tip in tips:
+        content += '<li>{}: {}</li>'.format(tip.tip_name, tip.get_id())
     content += '</ol>'
     return content
 
@@ -36,12 +45,18 @@ def search_results(search):
         if search.data['select'] == 'Recipe':
                 search_dict = form_to_recipe_dict(search.data)
                 results = Recipe.query.recipe_from_dict(search_dict)
+                search_type = 'recipe'
+
+        elif search.data['select'] == 'Tip':
+            search_dict = form_to_tip_dict(search.data)
+            results = Tip.query.tip_from_dict(search_dict)
+            search_type = 'tip'
 
         if not results:
                 flash('No results found!')
                 return redirect('/')
         else:
-                return render_template('search.html', form=s_form, results=results)
+                return render_template('search.html', form=s_form, results=results, search_type=search_type)
 
 @app.route('/upload_recipe', methods=['GET', 'POST'])
 def add_new_recipe():
@@ -74,28 +89,43 @@ def add_new_recipe():
     # Render the upload recipe form in the case of GET method.
     return render_template('upload_recipe_form.html')
 
+@app.route('/upload_tip', methods=['GET', 'POST'])
+def add_new_tip():
+    """Uses form input to add a new recipe to the database.
+    """
+    if request.method == 'POST':
+        request_dict = request_to_dict(request)
+        print(request_dict)
+        # TODO: implement required fields and error handling.
+        new_tip = Tip(
+                tip_name=request_dict['tip_name'],
+                media_type=request_dict['media_type'],
+                media_url=request_dict['media_url'],
+                video_id=video_id_from_url(request_dict['media_url']),
+                difficulty=request_dict['difficulty'],
+                description=request_dict['description'],
+                equipment=request_dict['equipment'].split('\n'),
+                ingredients=request_dict['ingredients'].split('\n'),
+                instructions=request_dict['instructions'].split('\n'),
+                tags=request_dict['tag'])
+
+        new_tip.save()
+        return render_template('upload_tip_success.html')
+    return render_template('upload_tip_form.html')
+
 # @app.route('/<recipe_type>')
 # def cookie_page(recipe_type):
 #       search_dict = {'recipe_name':recipe_type}
 #       recipe = Recipe.query.recipe_from_dict(search_dict).first()
 #       return render_template('recipe_page.html', recipe=recipe)
 
-@app.route('/<recipe_id>')
+@app.route('/recipe/<recipe_id>')
 def specific_recipe(recipe_id):
         recipe = Recipe.query.get_or_404(recipe_id)
         return render_template('recipe_template.html', recipe=recipe)
 
-@app.route('/upload_tip', methods=['GET', 'POST'])
-def add_new_tip():
-    """Uses form input to add a new tip to the database.
-    """
-    if request.method == 'POST':
-        request_dict = request_to_dict(request)
-        new_tip = Tip(
-                title=request_dict['tip_name'],
-                text=request_dict['description'],
-                submitter='Ariana',
-                related_equip=request_dict['equipment'].split('\n'),
-                related_ingr=request_dict['equipment'].split('\n'))
-        return render_template('upload_tip_success.html')
-    return render_template('upload_tip_form.html')
+@app.route('/tip/<tip_id>')
+def specific_tip(tip_id):
+    tip = Tip.query.get_or_404(tip_id)
+    return render_template('tip_template.html', tip=tip)
+

--- a/app/templates/edit_recipe.html
+++ b/app/templates/edit_recipe.html
@@ -1,0 +1,160 @@
+<doctype html>
+<head>
+	<title>Edit Recipe</title>
+</head>
+<body>
+	<h1>Edit Recipes</h1>
+
+	<ol id="demo"></ol>
+	<form id="upload_recipe_form" method="post">
+		<div name="recipename" id="recipename">
+			<label for="recipe_name">Recipe Name: </label>
+			<input type="text" name="recipe_name" id="recipe_name" value={{ recipe.recipe_name }}>
+			<br><br>
+		</div>
+		<div name="medialink" id="medialink">
+			<label for="medialink">Optional: Provide Supplemental Audio or Video to the Recipe</label>
+			<br>
+			{% if recipe.media_type == 'Audio' %}
+			<input type="radio" name="media_type" id="audio" value="Audio" checked="checked">
+			{% else %}
+			<input type="radio" name="media_type" id="audio" value="Audio">
+			{% endif %}
+			<label for="audio">Audio</label>
+
+			<br>
+			{% if recipe.media_type == 'Video' %}
+			<input type="radio" name="media_type" id="video" value="Video" checked="checked">
+			{% else %}
+			<input type="radio" name="media_type" id="video" value="Video">
+			{% endif %}
+			<label for="video">Video</label>
+
+			<br>
+			{% if recipe.media_type == 'No Supplemental Media' %}
+			<input type="radio" name="media_type" id="nomedia" value="No Supplemental Media" checked="checked">
+			{% else %}
+			<input type="radio" name="media_type" id="nomedia" value="No Supplemental Media">
+			{% endif %}
+			<label for="nomedia">No Supplemental Media</label>
+
+			<br>
+			<label for="media_url">Link:</label>
+			<input type="url" name="media_url" id="media_url" value={{ recipe.media_url }}>
+		</div>
+		<div name="recipeinfo" id="recipeinfo">
+			<br>
+			<label for="recipeinfo">Information About the Recipe</label>
+			<br>
+			<label for="difficulty">Difficulty:</label>
+			<select name="difficulty" id="difficulty">
+				{% if recipe.difficulty == 'beginner' %}
+				<option value="beginner" selected="selected">Beginner</option>
+				{% else %}
+				<option value="beginner">Beginner</option>
+				{% endif %}
+
+				{% if recipe.difficulty == 'intermediate' %}
+				<option value="intermediate" selected="selected">Intermediate</option>
+				{% else %}
+				<option value="intermediate">Intermediate</option>
+				{% endif %}
+
+				{% if recipe.difficulty == 'advanced' %}
+				<option value="advanced" selected="selected">Advanced</option>
+				{% else %}
+				<option value="advanced">Advanced</option>
+				{% endif %}
+			</select>
+			<br>
+			<label for="description">Description:</label>
+			<br>
+			<textarea name="description" id="desciption" rows="10" cols="50" 
+							  >{{ recipe.description }}</textarea>
+			<br>
+			<label for="time">Time:</label>
+			<input type="text" name="time" id="time" value={{ recipe.time }}>
+			<br>
+			<label for=servings>Yield:</label>
+			<input type="text" name="servings" id="servings" value={{ recipe.servings }}>
+			<br>
+		</div>
+		<div name="recipedetails" id="recipedetails">
+			<br>
+			<label for="recipedetails">Recipe Details</label>
+			<br>
+			<label for="equipment">Equipment:</label>
+			<br>
+			<textarea 
+				name="equipment" 
+				id="equipment"
+				rows="10"
+				cols="50"
+				>{{ '\n'.join(recipe.equipment) }}</textarea>
+			<br>
+			<label for=ingredients>Ingredients (with quantities):</label>
+			<br>
+			<textarea 
+				name="ingredients" 
+				id="ingredients"
+				rows="10"
+				cols="50"
+				>{{ '\n'.join(recipe.ingredients) }}</textarea>
+			<br>
+			<label for="instructions">Procedure:</label>
+			<br>
+			<textarea
+				name="instructions"
+				id="instructions"
+				rows="10" cols="50"
+				>{{ '\n'.join(recipe.instructions) }}</textarea>
+			<br>
+		</div>
+		<div name="recipetags" id="recipetags">
+			<br>
+			<label for="recipetags">Add Tags to the Recipe</label>
+			<br>
+			<label for="tag_checkboxes">Select Your Tags:</label>
+			<div name="tag_checkboxes" id="tag_checkboxes">
+				<label for=tag1>Breakfast</label>
+				{% if 'Breakfast' in recipe.tags %}
+				<input type="checkbox" name="tag" id="tag1" value="Breakfast" checked>
+				{% else %}
+				<input type="checkbox" name="tag" id="tag1" value="Breakfast">
+				{% endif %}
+				<br>
+				<label for=tag2>Lunch</label>
+				{% if 'Lunch' in recipe.tags %}
+				<input type="checkbox" name="tag" id="tag2" value="Lunch" checked>
+				{% else %}
+				<input type="checkbox" name="tag" id="tag2" value="Lunch">
+				{% endif %}
+				<br>
+				<label for=tag3>Dinner</label>
+				{% if 'Dinner' in recipe.tags %}
+				<input type="checkbox" name="tag" id="tag3" value="Dinner" checked>
+				{% else %}
+				<input type="checkbox" name="tag" id="tag3" value="Dinner">
+				{% endif %}
+				<br>
+				<label for=tag4>Dessert</label>
+				{% if 'Dessert' in recipe.tags %}
+				<input type="checkbox" name="tag" id="tag4" value="Dessert" checked>
+				{% else %}
+				<input type="checkbox" name="tag" id="tag4" value="Dessert">
+				{% endif %}
+				<br>
+			</div>
+		</div>
+		<div name="addtips" id="addtips">
+			<textarea 
+				name="tiplinks" 
+				id="tiplinks"
+				rows="10"
+				cols="50"
+				>{{ '/n'.join(tips) }}</textarea>
+		</div>
+		<br><br>
+		<input type="submit" name="submit_recipe" value="Revise Recipe">
+	</form>
+</body>

--- a/app/templates/recipe_template.html
+++ b/app/templates/recipe_template.html
@@ -18,7 +18,7 @@
 		<br>
 		<label for="audio">Audio Supplement</label>
 		<br>
-		<a href={{ recipe.media_url }} target="_blank">Navigate to supplemental audio. Opens in new tab</a>
+		<a href={{ recipe.media_url }} target="_blank" id="audio">Navigate to supplemental audio. Opens in new tab.</a>
 		{% endif %}
 
 		{% if recipe.media_type == 'No Supplemental Media' %}
@@ -57,6 +57,12 @@
 			<li>There are no instructions for this recipe.</li>
 			{% endfor %}
 		</ol>
+		<h2>Related Tips</h2>
+		<ul>
+			{% for tip in recipe.tips %}
+			<a href={{ "/" + tip.get_id() }} target="_blank">{{ tip.name }}</a>
+			{% endfor %}
+		</ul>
 	</body>
 
 </html>

--- a/app/templates/recipe_template.html
+++ b/app/templates/recipe_template.html
@@ -60,7 +60,7 @@
 		<h2>Related Tips</h2>
 		<ul>
 			{% for tip in recipe.tips %}
-			<li><a href={{ "/" + tip.get_id() }} target="_blank">{{ tip.name }}</a></li>
+			<li><a href={{ "/tip/" + tip.get_id() }} target="_blank">{{ tip.tip_name }}</a></li>
 			{% else %}
 			<li>There are currently no related tips associated with this recipe.</li>
 			{% endfor %}

--- a/app/templates/recipe_template.html
+++ b/app/templates/recipe_template.html
@@ -60,7 +60,9 @@
 		<h2>Related Tips</h2>
 		<ul>
 			{% for tip in recipe.tips %}
-			<a href={{ "/" + tip.get_id() }} target="_blank">{{ tip.name }}</a>
+			<li><a href={{ "/" + tip.get_id() }} target="_blank">{{ tip.name }}</a></li>
+			{% else %}
+			<li>There are currently no related tips associated with this recipe.</li>
 			{% endfor %}
 		</ul>
 	</body>

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -32,14 +32,14 @@
 	<dl>
 		{% if search_type == 'recipe' %}
 		{% for result in results %}
-		<dt><a href="{{search_type}}/{{result.get_id()}}">{{result.recipe_name}}</a></dt>
+		<dt><a href="/{{search_type}}/{{result.get_id()}}">{{result.recipe_name}}</a></dt>
 		<dd>{{result.description}}</dd>
 		{% endfor %}
 		{% endif %}
 
 		{% if search_type == 'tip' %}
 		{% for result in results %}
-		<dt><a href="{{search_type}}/{{result.get_id()}}">{{result.tip_name}}</a></dt>
+		<dt><a href="/{{search_type}}/{{result.get_id()}}">{{result.tip_name}}</a></dt>
 		<dd>{{result.description}}</dd>
 		{% endfor %}
 		{% endif %}

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -30,10 +30,19 @@
 <body>
 	{% if results %}
 	<dl>
+		{% if search_type == 'recipe' %}
 		{% for result in results %}
-		<dt><a href="/{{result.get_id()}}">{{result.recipe_name}}</a></dt>
+		<dt><a href="{{search_type}}/{{result.get_id()}}">{{result.recipe_name}}</a></dt>
 		<dd>{{result.description}}</dd>
 		{% endfor %}
+		{% endif %}
+
+		{% if search_type == 'tip' %}
+		{% for result in results %}
+		<dt><a href="{{search_type}}/{{result.get_id()}}">{{result.tip_name}}</a></dt>
+		<dd>{{result.description}}</dd>
+		{% endfor %}
+		{% endif %}
 	</dl>
 	{% else %}
 	<p>No results found</p>

--- a/app/templates/tip_template.html
+++ b/app/templates/tip_template.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Tips</title>
+	</head>
+	<body>
+		<h1>{{ tip.title }}</h1>
+		<h2>Supplemental Media</h2>
+			{% if tip.media_type == 'Video' %}
+			<label for="video">Video Supplement</label>
+			<br>
+			<iframe width="854" height="480"
+				src={{ "https://www.youtube.com/embed/" + tip.video_id }} frameborder="0"
+				allowfullscreen id="video"></iframe>
+			{% endif %}
+			{% if tip.media_type == 'Audio' %}
+			<label for="audio">Audio Supplement</label>
+			<a href={{ tip.media_url }} target="_blank" id="audio">Link to supplemental audio. Opens in new tab</a>
+			{% endif %}
+			{% if tip.media_type == 'No Supplemental Media' %}
+			<p>There is no supplemental media for this tip</p>
+			{% endif %}
+		<h2>About</h2>
+			<h3>Description</h3>
+				<p>{{ tip.description }}</p>
+			<h3>Difficulty</h3>
+				<p>{{ tip.difficulty }}</p>
+		<h2>Equipment</h2>
+			<ul>
+				{% for equipment in tip.equipment %}
+				<li>{{ equipment }}</li>
+				{% endfor %}
+			</ul>
+		<h2>Ingredients</h2>
+			<ul>
+				{% for ingredient in tip.ingredients %}
+				<li>{{ ingredient }}</li>
+				{% endfor %}
+			</ul>
+		<h2>Instructions</h2>
+			<ol>
+				{% for instruction in tip.instructions %}
+				<li>{{ instruction }}</li>
+				{% endfor %}
+			</ol>
+
+	</body>

--- a/app/templates/upload_tip_form.html
+++ b/app/templates/upload_tip_form.html
@@ -15,13 +15,13 @@
             <div name="medialink" id="medialink">
                 <label for="medialink">Optional: Provide Supplemental Audio or Video for the Tip</label>
                 <br>
-                <input type="radio" name="mediatype" id="audio" value="Audio">
+                <input type="radio" name="media_type" id="audio" value="Audio">
                 <label for="audio">Audio</label>
                 <br>
-                <input type="radio" name="mediatype" id="video" value="Video">
+                <input type="radio" name="media_type" id="video" value="Video">
                 <label for="video">Video</label>
                 <br>
-                <input type="radio" name="mediatype" id="nomedia" value="No Supplemental Media">
+                <input type="radio" name="media_type" id="nomedia" value="No Supplemental Media">
                 <label for="nomedia">No Supplemental Media</label>
                 <br>
                 <label for="media_url">Link:</label>
@@ -49,20 +49,29 @@
                 <br>
                 <label for="tipdetails">Tip Details</label>
                 <br>
-                <label for="equipment">Equipment and ingredients:</label>
+                <label for="equipment">Equipment:</label>
                 <br>
                 <textarea 
                     name="equipment" 
                     id="equipment"
                     rows="10"
                     cols="50"
-                    placeholder="Type each ingredient or piece of equipment on its own line"></textarea>
+                    placeholder="Type each piece of equipment on its own line"></textarea>
                 <br>
-                <label for="instruction">Procedure:</label>
+                <label for="ingredients">Ingredients:</label>
+                <br>
+                <textarea 
+                    name="ingredients" 
+                    id="ingredients"
+                    rows="10"
+                    cols="50"
+                    placeholder="Type each ingredient its own line"></textarea>
+                <br>
+                <label for="instructions">Indtructions:</label>
                 <br>
                 <textarea
-                    name="instruction"
-                    id="instruction"
+                    name="instructions"
+                    id="instructions"
                     rows="10" cols="50"
                     placeholder="Type each instruction on its own line"></textarea>
                 <br>
@@ -87,9 +96,7 @@
                     <br>
                 </div>
             </div>
-            <br>
-            <input type="button" name="review_tip" value="Review Tip">
-            <br><br>
+	    <br><br>
             <input type="submit" name="submit_tip" value="Submit Tip">
     </form>
 </body>


### PR DESCRIPTION
There is now a route and a form to edit a recipe, including a field to add tips. The tip field is a bit of a placeholder for a better implementation. The moderator must put in the id of the tip and cannot search for tips to add currently, but linking the tip this way does work correctly.

Changes of note:
1. Going to the route '/edit/<recipe_id>' will open a page with the edit recipe form filled out with the current recipe values. This is the same form as the upload recipe form with the addition of a place to list tip ids
2. Tips linked to recipes are displayed in a section of the recipe page, in no particular order. They are links that when clicked open a new tab with the tip page.

Edit form:
![image](https://user-images.githubusercontent.com/15851197/39460328-a1e89740-4cd0-11e8-9fbc-0d6f4ecd208c.png)

Linked tips on recipe page:
![image](https://user-images.githubusercontent.com/15851197/39460349-c4ee0c84-4cd0-11e8-9381-6434424a5da3.png)

Future work would include integrating tip searching into the form, and creating some mechanism for moderators to find and edit recipes without copying and pasting ids into the url. Also, creating and edit tip page.